### PR TITLE
[FIX] added missing comma in the opener.py

### DIFF
--- a/web_auto_refresh/__openerp__.py
+++ b/web_auto_refresh/__openerp__.py
@@ -20,7 +20,7 @@
 ##############################################################################
 
 {
-    'name': 'Auto Refresh inbox message, Kanban and list view'
+    'name': 'Auto Refresh inbox message, Kanban and list view',
     'version': '1.0',
     'author': "Fisher, Odoo Community Association (OCA)",
     'website': 'https://github.com/szufisher/web',


### PR DESCRIPTION
I added a missing comma, which made the add-on Auto Refresh installable.
